### PR TITLE
Fix navigation failing due to missing status helper

### DIFF
--- a/email-builder-app-2/index.html
+++ b/email-builder-app-2/index.html
@@ -16,7 +16,7 @@
   </style>
 </head>
 <body>
-  <noscript>This app requires JavaScript to run.</noscript>>
+  <noscript>This app requires JavaScript to run.</noscript>
 <div id="status-banner" style="position:fixed;top:0;left:0;width:100%;background:#ffdddd;color:#900;padding:5px;font-size:14px;z-index:9999;display:none"></div>
 
   <header>

--- a/email-builder-app-2/js/app.js
+++ b/email-builder-app-2/js/app.js
@@ -23,6 +23,23 @@ function showStatus(msg){
   }
 }
 
+// Inline status bar helper used throughout the app
+function setStatus(msg, type){
+  const bar = document.getElementById('statusBar');
+  if(!bar) return;
+
+  // Reset previous state
+  bar.classList.remove('hidden', 'ok', 'warn', 'err');
+  bar.textContent = msg || '';
+
+  // Apply new type if provided; hide if message empty
+  if(!msg){
+    bar.classList.add('hidden');
+  } else if(type){
+    bar.classList.add(type);
+  }
+}
+
 
 // Global error guards to avoid silent failures that freeze routing
 window.addEventListener('error', (e) => { console.warn('[app error]', e.message); showStatus('[Error] ' + e.message); });


### PR DESCRIPTION
## Summary
- implement `setStatus` to update the inline status bar and avoid missing function errors
- tidy index.html by removing stray character in `<noscript>` block

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a536f163748333964fd0ab37531a99